### PR TITLE
Fix drafts folder detection using non-existent imapclient constant

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -353,11 +353,10 @@ def detect_archive_folder(client: IMAPClient) -> str:
 
 
 def detect_drafts_folder(client: IMAPClient) -> str:
-    import imapclient as imc
-
-    result = client.find_special_folder(imc.DRAFTS)
-    if result:
-        return result
+    folders = client.list_folders()
+    for flags, _delim, name in folders:
+        if b"\\Drafts" in flags:
+            return name
     for name in ("Drafts", "[Gmail]/Drafts", "INBOX.Drafts"):
         if client.folder_exists(name):
             return name


### PR DESCRIPTION
## Summary
- `detect_drafts_folder` used `imapclient.DRAFTS` which doesn't exist, causing `create_draft` to fail
- `imapclient.DRAFT` is a message flag (`\Draft`), not the folder special-use attribute (`\Drafts`)
- Replaced with direct `list_folders()` iteration checking for the `\Drafts` RFC 6154 special-use flag, matching the approach already used by `detect_archive_folder`

## Test plan
- [ ] Verify `create_draft` successfully finds/creates drafts folder on Gmail
- [ ] Verify `create_draft` works on non-Gmail IMAP servers (e.g., Outlook, Fastmail)