### PR TITLE
Fix emails marked as read despite mark_as_read: false

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -441,7 +441,11 @@ async def watch_folder(
         client = None
         try:
             client = await asyncio.to_thread(get_imap_client, account)
-            await asyncio.to_thread(client.select_folder, folder)
+            await asyncio.to_thread(
+                client.select_folder,
+                folder,
+                readonly=not account.get("mark_as_read", False),
+            )
 
             # Check IDLE support
             if not client.has_capability("IDLE"):


### PR DESCRIPTION
## Summary
- Opens IMAP folder in `readonly` mode when `mark_as_read` is `false` (the default)
- Prevents `FETCH RFC822` from implicitly setting the `\Seen` flag per IMAP RFC
- Fixes bug reported on PR #6

## Test plan
- [ ] Configure `mark_as_read: false`, verify new emails stay unread after webhook delivery
- [ ] Configure `mark_as_read: true`, verify emails are marked as read as before