### PR TITLE
Send IMAP ID after login (fixes netease login rejection)

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -265,6 +265,15 @@ def resolve_account(accounts: list[dict], account_id: str) -> dict:
 # ---------------------------------------------------------------------------
 
 
+# RFC 2971 IMAP ID — required by some providers (e.g. netease 163.com / 126.com / yeah.net)
+# which reject clients that don't identify themselves after login.
+_IMAP_CLIENT_ID = {
+    "name": "poke-mail",
+    "version": "1.0.0",
+    "vendor": "Poke Interactions",
+}
+
+
 def get_imap_client(account: dict) -> IMAPClient:
     port = account["imap_port"]
     use_ssl = port == 993
@@ -272,6 +281,13 @@ def get_imap_client(account: dict) -> IMAPClient:
     if not use_ssl:
         client.starttls()
     client.login(account["imap_username"], account["imap_password"])
+    # Send IMAP ID if the server supports it. Non-fatal: not all servers do,
+    # and we never want this to break an otherwise-working login.
+    try:
+        if client.has_capability("ID"):
+            client.id_(_IMAP_CLIENT_ID)
+    except Exception as e:
+        logger.debug("IMAP ID command failed for %s: %s", account.get("id"), e)
     return client
 
 


### PR DESCRIPTION
Closes #10

Some IMAP providers — notably netease (163.com / 126.com / yeah.net) — reject clients that don't issue an RFC 2971 `ID` command after login. `get_imap_client()` never sent one, so logins to those providers failed.

## Change
After a successful login, if the server advertises the `ID` capability, send a minimal client identification (`name`, `version`, `vendor`) via `IMAPClient.id_()`.

## Safety
- Guarded by `client.has_capability("ID")` so we only send when supported.
- Wrapped in try/except — any failure is logged at debug and never breaks an otherwise-working login.
- No behavior change for providers that don't advertise `ID` (Gmail, iCloud, etc.).

Reporter (#10) verified a near-identical patch works against netease.