### PR TITLE
Skip MCP_API_KEY generation in tunnel mode

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -207,10 +207,23 @@ PYEOF
   fi
 fi
 
-# 4. MCP_API_KEY — generate once and persist to .env
-if [ ! -f .env ] \
+# ── Load .env early so POKE_TUNNEL is visible to the MCP_API_KEY logic below ──
+if [ -f .env ]; then
+  set -a
+  source .env
+  set +a
+fi
+
+# Tunnel-mode detection must happen BEFORE the MCP_API_KEY block: in tunnel
+# mode (POKE_TUNNEL=1, the default) the local server runs unauthenticated and
+# the tunnel handles auth, so we must NOT generate a key — doing so previously
+# overwrote user-supplied keys and broke working setups (issue #9).
+POKE_TUNNEL="${POKE_TUNNEL:-1}"
+
+# 4. MCP_API_KEY — generate once and persist to .env (skipped in tunnel mode)
+if [ "${POKE_TUNNEL}" != "1" ] && { [ ! -f .env ] \
    || grep -Eq '^[[:space:]]*MCP_API_KEY=your-secret-key-here' .env 2>/dev/null \
-   || ! grep -Eq '^[[:space:]]*MCP_API_KEY=.+' .env 2>/dev/null; then
+   || ! grep -Eq '^[[:space:]]*MCP_API_KEY=.+' .env 2>/dev/null; }; then
   RANDOM_KEY=$(python3 -c "
 import secrets, string
 alphabet = string.ascii_letters + string.digits
@@ -233,18 +246,13 @@ PYEOF
   fi
   echo "  ✓ MCP_API_KEY generated and saved to .env"
   echo ""
-fi
-
-# ── Load .env ─────────────────────────────────────────────────────────────────
-if [ -f .env ]; then
+  # Re-source so the freshly generated key is visible to the rest of the script
   set -a
   source .env
   set +a
 fi
 
-# ── Tunnel-mode detection ─────────────────────────────────────────────────────
-POKE_TUNNEL="${POKE_TUNNEL:-1}"
-
+# ── Tunnel-mode enforcement ───────────────────────────────────────────────────
 if [ "${POKE_TUNNEL}" != "1" ]; then
   : "${MCP_API_KEY:?MCP_API_KEY is not set — add it to .env or export it}"
 else


### PR DESCRIPTION
Closes #9

`start.sh` previously generated and persisted an `MCP_API_KEY` to `.env` on first run, regardless of `POKE_TUNNEL`. In tunnel mode (`POKE_TUNNEL=1`, the default) the local server runs unauthenticated and the Poke tunnel handles auth — generating a key there is at best useless and at worst overwrites a user-supplied key, causing 421 errors at the tunnel.

## Change
- Move `.env` loading and `POKE_TUNNEL` resolution **above** the `MCP_API_KEY` generation block.
- Skip generation entirely when `POKE_TUNNEL=1`.
- Re-source `.env` after a successful generation so the rest of the script sees the new value.
- Removed the duplicate `.env` load further down (now redundant).

## Behavior matrix

| POKE_TUNNEL | .env exists / key present | Action |
|---|---|---|
| 1 (default) | any | **No key generated** (was: generated, sometimes overwriting user key) |
| 0 | no .env or placeholder/missing key | Generate + persist (unchanged) |
| 0 | valid key already present | Leave alone (unchanged) |