### PR TITLE
Make the scratch image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,15 @@
 # ---- build ----------------------------------------------------------------
 FROM golang:1.25-alpine AS build
 
+# ca-certificates for TLS verification at runtime. Timezone data is embedded
+# in the binary instead (see the time/tzdata import), since Alpine ships no
+# /usr/share/zoneinfo to copy.
+RUN apk add --no-cache ca-certificates
+
+# An empty directory to become a writable /tmp on scratch, where
+# get_attachment writes files.
+RUN mkdir -p /emptytmp && chmod 1777 /emptytmp
+
 WORKDIR /src
 
 # Dependencies first so a source-only change reuses the module cache.
@@ -25,12 +34,10 @@ FROM scratch
 
 # TLS roots, so IMAP and SMTP certificate verification works.
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-# Timezone data, so message dates render correctly.
-COPY --from=build /usr/share/zoneinfo /usr/share/zoneinfo
 COPY --from=build /out/mail-mcp /mail-mcp
 
 # Writable location for get_attachment.
-COPY --from=build --chown=65534:65534 /tmp /tmp
+COPY --from=build --chown=65534:65534 /emptytmp /tmp
 
 # nobody: nothing here needs root.
 USER 65534:65534

--- a/cmd/mail-mcp/main.go
+++ b/cmd/mail-mcp/main.go
@@ -18,6 +18,11 @@ import (
 	"syscall"
 	"time"
 
+	// Embed the timezone database in the binary. Message Date headers carry
+	// zone names as well as numeric offsets, and the runtime image is
+	// scratch — there is no /usr/share/zoneinfo to fall back on.
+	_ "time/tzdata"
+
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/kacperkwapisz/mail-mcp/internal/config"


### PR DESCRIPTION
The Docker job failed copying `/usr/share/zoneinfo` out of the builder:

```
failed to compute cache key: "/usr/share/zoneinfo": not found
```

Alpine ships no timezone database, so there was nothing to copy.

Embeds the database in the binary via a `time/tzdata` import instead. That suits a scratch runtime better than installing tzdata and copying files out — message `Date` headers carry zone names as well as numeric offsets, and there is now nothing outside the binary that can go missing. Costs roughly 450 KB.

Also:

- Replaces the copy of the builder's `/tmp` — which dragged along whatever build residue happened to be in it — with a purpose-made empty directory.
- Installs `ca-certificates` explicitly rather than relying on the base image happening to include them.

`test` and `lint` already pass on main after #17; this is the last red job.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the scratch Docker image build by embedding timezone data in the binary and removing reliance on Alpine’s tz files. Previously we copied `/usr/share/zoneinfo` from the builder and the step failed; now we import `time/tzdata`. Binary size increases by ~450 KB, and the runtime no longer depends on external tz files.

- Installs `ca-certificates` in the build stage and copies the CRT into the scratch image so IMAP/SMTP TLS verification works reliably.
- Replaces copying the builder’s `/tmp` with a clean empty directory (mode 1777) to provide a writable `/tmp` for get_attachment without dragging build residue.
- Removes the `COPY` of `/usr/share/zoneinfo`; message Date headers still render zone names via the embedded database.

<sup>Written for commit 26778804714361f382c3b30fd8c8aa8f9612c9ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kacperkwapisz/mail-mcp/pull/18?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

