### PR TITLE
Stop ignore rules from swallowing source files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: "1.25"
           cache: true
@@ -27,6 +27,27 @@ jobs:
             echo "$unformatted"
             exit 1
           fi
+
+      # Regression test for .gitignore itself. An unanchored "mail-mcp" rule
+      # once matched the cmd/mail-mcp/ directory, so `git add cmd` was a
+      # silent no-op and a commit shipped with no package main. check-ignore
+      # works on hypothetical paths, so this catches the rule before a file
+      # exists to be lost.
+      - name: Verify ignore rules do not swallow source
+        run: |
+          status=0
+          for path in \
+            cmd/mail-mcp/main.go \
+            internal/config/testdata/config.yml \
+            internal/mailmime/testdata/sample.out \
+            internal/tools/testdata/golden.yml
+          do
+            if git check-ignore -q "$path"; then
+              echo "::error::.gitignore would silently swallow $path"
+              status=1
+            fi
+          done
+          exit $status
 
       - name: Verify go.mod is tidy
         run: |
@@ -53,8 +74,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: "1.25"
           cache: true
@@ -67,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: docker/setup-buildx-action@v3
       - uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,9 +23,9 @@ jobs:
           - { goos: darwin, goarch: amd64 }
           - { goos: darwin, goarch: arm64 }
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: "1.25"
           cache: true
@@ -69,7 +69,7 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3

--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,15 @@
-# Secrets — never commit these
+# Secrets — never commit these.
+# Deliberately unanchored: a stray config.yml in any subdirectory would hold
+# credentials too, so the broad match is the point.
 config.yml
 .env
 .env.*
 !.env.example
 
 # Build output.
-# These are anchored with a leading slash on purpose: an unanchored
-# "mail-mcp" would also match the cmd/mail-mcp/ source directory.
+# Anchored with a leading slash on purpose. An unanchored "mail-mcp" matches
+# at any depth, which once swallowed the cmd/mail-mcp/ source directory and
+# shipped a commit with no package main.
 /bin/
 /dist/
 /mail-mcp
@@ -21,3 +24,9 @@ coverage.*
 .vscode/
 .idea/
 .claude/
+
+# Test fixtures are source, not build output. This has to stay last so it
+# overrides everything above: several rules here are broad enough to swallow
+# a golden file, and a silently untracked fixture is exactly how the
+# entrypoint went missing. CI asserts these paths stay trackable.
+!**/testdata/**


### PR DESCRIPTION
The missing entrypoint fixed in #17 was one symptom of a rule that is still live.

`config.yml` and `*.out` are both unanchored, so a future test fixture at `internal/config/testdata/config.yml` or `internal/mailmime/testdata/sample.out` would be silently untracked in exactly the same way. Tests would pass locally against files that never reached the repo, and CI would fail somewhere unrelated.

Verified before the fix:

```
internal/config/testdata/config.yml       IGNORED
internal/mailmime/testdata/sample.out     IGNORED
```

## Changes

Test fixtures are source, not build output, so `testdata` is now explicitly re-included. The negation has to sit last in the file to override the broad rules above it.

`config.yml` stays unanchored deliberately — a stray config in any subdirectory holds credentials too, and catching those matters more than the inconvenience of needing the escape hatch.

## Guard

CI now asserts the ignore rules against representative source paths. `git check-ignore` evaluates hypothetical paths, so this fails on the *rule* rather than waiting for someone to lose a file to it — which is the part that made the original bug invisible.

Also moves `actions/checkout` to v5 and `actions/setup-go` to v6, clearing the Node 20 deprecation warnings on every run.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops .gitignore rules from hiding source files and adds a CI guard to catch regressions. Old behavior: unanchored patterns could silently ignore `cmd/mail-mcp/` and `**/testdata/**` fixtures; new behavior: build outputs are anchored and `testdata` is explicitly re-included. `config.yml` remains unanchored to protect secrets.

**Review notes**
- `.gitignore`: anchor build outputs (`/bin/`, `/dist/`, `/mail-mcp`), keep unanchored `config.yml`, and add final `!**/testdata/**` (must remain last to override broader rules).
- CI: add a “Verify ignore rules do not swallow source” step using `git check-ignore` against representative paths (e.g., `cmd/mail-mcp/main.go`, `internal/**/testdata/**`) to fail on the rule, not after a file is lost; bump `actions/checkout` to `v5` and `actions/setup-go` to `v6` to clear Node 20 deprecation warnings.
- Migration: if you keep fixtures named `config.yml` or `*.out`, place them under a `testdata` directory so they stay tracked.

<sup>Written for commit d21ecefd0833597aa990544638d652d43a7c667a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kacperkwapisz/mail-mcp/pull/19?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

