### PR TITLE
Only stable tags move the latest Docker tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,7 +88,9 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            type=raw,value=latest
+            # Only stable tags move :latest. A prerelease such as v1.1.0-rc1
+            # must not become what `docker pull` gives people by default.
+            type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
 
       - uses: docker/build-push-action@v6
         with:


### PR DESCRIPTION
Prep for the first release.

`type=raw,value=latest` was applied unconditionally, so a future prerelease like `v1.1.0-rc1` would become what `docker pull ghcr.io/kacperkwapisz/mail-mcp` returns by default. Now gated on the tag having no prerelease suffix.

Also verified the rest of the release workflow by running its build steps verbatim against a clean clone: all four `GOOS/GOARCH` targets compile, archives and checksums are produced correctly, and the extracted binary reports the injected version.