### PR TITLE
Actually run the container image in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,23 @@ jobs:
         with:
           context: .
           push: false
+          load: true
           tags: mail-mcp:test
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      # Building a scratch image proves nothing about whether it runs. A
+      # missing cert bundle or a stray dynamic link would otherwise only
+      # surface once someone pulled it.
+      - name: Smoke-test the image
+        run: |
+          docker run --rm mail-mcp:test --version
+
+          # With no config mounted, startup must fail with a clear message
+          # rather than panicking or hanging.
+          output=$(docker run --rm mail-mcp:test 2>&1 || true)
+          echo "$output"
+          case "$output" in
+            *"read config"*) ;;
+            *) echo "::error::unexpected startup output from the image"; exit 1 ;;
+          esac

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,3 +102,11 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      # Pull the artifact that was just published and run it, so a broken
+      # image is caught here rather than by whoever pulls it next.
+      - name: Verify the published image runs
+        run: |
+          image="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}"
+          docker pull "$image"
+          docker run --rm "$image" --version


### PR DESCRIPTION
The image was built on every push and published on every tag, but never executed.

Building a scratch image proves the binary compiles and the `COPY` paths resolve. It says nothing about whether the result *starts* — a missing cert bundle or an accidental dynamic link would surface only when someone pulled it. The `v1.0.0` image I just published was verified by inspecting its config blob (entrypoint, non-root user, env, layer count), which is good but not the same as running it.

CI now loads the image and runs it, asserting that `--version` works and that a missing config yields a clear error rather than a panic or a hang. The release workflow pulls the artifact it just pushed and runs that as well, so a broken publish is caught before a user finds it.