### PR TITLE
Mint a 15-minute download URL from get_attachment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,9 +56,9 @@ Do not skip vet or tests for code changes.
 | `internal/mailbox` | IMAP connection pool and operations |
 | `internal/send` | SMTP composition, delivery, validation |
 | `internal/tools` | MCP tool definitions and handlers |
-| `internal/httpx` | Bearer auth, rate limiting, route filtering, security headers |
+| `internal/httpx` | Bearer auth, rate limiting, route filtering, security headers, signed attachment downloads |
 
-Keep the layering one-directional: `tools` depends on `mailbox`/`send`/`config`, never the reverse.
+Keep the layering one-directional: `tools` depends on `mailbox`/`send`/`config`/`httpx`, never the reverse. `httpx` must not import `tools`.
 
 ## Invariants — Do Not Break These
 
@@ -80,7 +80,7 @@ A `message_id` encodes account + mailbox + UIDVALIDITY + UID. Consequences:
 
 ### Attachment bytes stay out of responses
 
-`read_email` returns metadata only. `get_attachment` writes to disk and returns a path. Do not add an option that inlines attachment content into a tool result.
+`read_email` returns metadata only. `get_attachment` writes to disk and returns `file_path` plus, when `public_url` is set, a 15-minute HMAC `download_url`. Do not add an option that inlines attachment content into a tool result. The download token is HMAC-SHA256 of expiry+filename keyed with `MCP_API_KEY`; verification failures are 404, never 401, so scanners learn nothing.
 
 ### Send validation precedes the network
 
@@ -141,4 +141,4 @@ Explain *why*, not *what*. Existing comments justify non-obvious decisions — t
 - Prefer minimal, focused diffs.
 - Do not rename tools without an explicit request — clients cache them.
 - Do not add compatibility shims unless asked. The one exception already present is legacy flat config keys, which exist to carry poke-mail v1 configs across the rename.
-- Adding an env var or config key means updating `config.example.yml`, `.env.example`, `README.md`, and this file together.
+- Adding an env var or config key means updating `config.example.yml`, `.env.example` (env vars only), `README.md`, and this file together.

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ For a client on the same machine, stdio skips the network entirely and needs no 
 | ---------------- | ------------------------------------------------------------------------ |
 | `search_emails`  | Search by sender, recipient, subject, body, date, or flags. Paginated.    |
 | `read_email`     | One message: headers, body, attachment metadata. HTML opt-in.             |
-| `get_attachment` | Write one attachment to disk, return the path.                            |
+| `get_attachment` | Write one attachment to disk. Returns `file_path` and, on HTTP, a 15-minute `download_url`. |
 
 **Sending**
 
@@ -137,7 +137,7 @@ For a client on the same machine, stdio skips the network entirely and needs no 
 
 ## Design decisions
 
-**Attachment bytes never enter the response.** `read_email` returns attachment metadata with a `part_id`; `get_attachment` writes the file to disk and returns a path. A 7 MB PDF base64-encoded into a tool result would blow the context window without accomplishing anything — hand the model a path and let it open the file with a local tool.
+**Attachment bytes never enter the response.** `read_email` returns attachment metadata with a `part_id`; `get_attachment` writes the file to disk and returns `file_path` (on the server) plus, when `public_url` is set, a 15-minute signed `download_url`. A remote agent curls that URL onto its own machine. A 7 MB PDF base64-encoded into a tool result would blow the context window without accomplishing anything.
 
 **Bodies are truncated and HTML is opt-in.** Message HTML is attacker-controlled and enormous. It is sanitized through bluemonday before it is ever returned, and omitted entirely unless `include_html` is set. Messages with no plain-text part get one derived from the HTML, with paragraph breaks preserved.
 
@@ -184,6 +184,7 @@ See [`config.example.yml`](config.example.yml) for the annotated version.
 | `limits.max_search_results`  | `100`          | Largest search page.                                       |
 | `limits.max_attachment_bytes`| `26214400`     | Attachment size ceiling.                                   |
 | `limits.attachment_dir`      | system temp    | Where `get_attachment` writes.                             |
+| `public_url`                 | empty          | Origin used to mint `download_url`. Empty disables it.     |
 | `timeouts.*`                 | see example    | `imap_connect`, `imap_command`, `smtp_connect`, `smtp_send`. |
 | `accounts[].allow_send`      | inherits global| Per-account send gate.                                     |
 | `accounts[].allow_delete`    | inherits global| Per-account delete gate.                                   |

--- a/cmd/mail-mcp/main.go
+++ b/cmd/mail-mcp/main.go
@@ -78,11 +78,13 @@ func run() error {
 	pool := mailbox.NewPool(cfg, logger)
 	defer pool.Close()
 
+	apiKey := strings.TrimSpace(os.Getenv("MCP_API_KEY"))
+
 	srv := mcp.NewServer(
 		&mcp.Implementation{Name: "mail-mcp", Version: version, Title: "Mail"},
 		&mcp.ServerOptions{Instructions: tools.Instructions, Logger: logger},
 	)
-	tools.New(cfg, pool, logger, version).Register(srv)
+	tools.New(cfg, pool, logger, version, apiKey).Register(srv)
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
@@ -92,16 +94,15 @@ func run() error {
 		logger.Info("serving on stdio", "version", version)
 		return srv.Run(ctx, &mcp.StdioTransport{})
 	case "http":
-		return serveHTTP(ctx, srv, logger, *addr, *trustProxy)
+		return serveHTTP(ctx, srv, cfg, logger, *addr, *trustProxy, apiKey)
 	default:
 		return fmt.Errorf("unknown transport %q: use http or stdio", *transport)
 	}
 }
 
-func serveHTTP(ctx context.Context, srv *mcp.Server, logger *slog.Logger, addr string, trustProxy bool) error {
+func serveHTTP(ctx context.Context, srv *mcp.Server, cfg *config.Config, logger *slog.Logger, addr string, trustProxy bool, apiKey string) error {
 	// No token, no server. This process can read and send a person's mail;
 	// starting it open to the network would be indefensible.
-	apiKey := strings.TrimSpace(os.Getenv("MCP_API_KEY"))
 	if apiKey == "" {
 		return errors.New("MCP_API_KEY is not set. The HTTP transport requires a bearer token — " +
 			"generate one with `openssl rand -hex 32`, or use --transport stdio for local-only use")
@@ -110,29 +111,21 @@ func serveHTTP(ctx context.Context, srv *mcp.Server, logger *slog.Logger, addr s
 		return errors.New("MCP_API_KEY is too short; use at least 16 characters (`openssl rand -hex 32`)")
 	}
 
-	handler := mcp.NewStreamableHTTPHandler(
+	mcpHandler := mcp.NewStreamableHTTPHandler(
 		func(*http.Request) *mcp.Server { return srv },
 		&mcp.StreamableHTTPOptions{Logger: logger, Stateless: true},
 	)
-
-	limiter := httpx.NewRateLimiter(
+	attachments := httpx.AttachmentHandler(apiKey, cfg.Limits.AttachmentDir, logger)
+	handler := httpx.Handler(
+		apiKey, logger, trustProxy,
 		envInt("RATE_LIMIT_GET_RPM", 60),
 		envInt("RATE_LIMIT_POST_RPM", 240),
-		trustProxy,
+		mcpHandler, attachments,
 	)
-
-	// Outermost first: unknown paths die before anything else runs, and
-	// authentication happens before rate-limit state is touched.
-	var wrapped http.Handler = handler
-	wrapped = httpx.RequireBearer(apiKey, logger, wrapped)
-	wrapped = limiter.Middleware(wrapped)
-	wrapped = httpx.SecurityHeaders(wrapped)
-	wrapped = httpx.LogRequests(logger, wrapped)
-	wrapped = httpx.OnlyPath(mcpPath, wrapped)
 
 	httpServer := &http.Server{
 		Addr:              addr,
-		Handler:           wrapped,
+		Handler:           handler,
 		ReadHeaderTimeout: 10 * time.Second,
 		IdleTimeout:       120 * time.Second,
 		ErrorLog:          slog.NewLogLogger(logger.Handler(), slog.LevelDebug),
@@ -140,7 +133,7 @@ func serveHTTP(ctx context.Context, srv *mcp.Server, logger *slog.Logger, addr s
 
 	serveErr := make(chan error, 1)
 	go func() {
-		logger.Info("listening", "addr", addr, "path", mcpPath, "version", version)
+		logger.Info("listening", "addr", addr, "path", mcpPath, "attachments", httpx.DownloadPrefix, "version", version)
 		if err := httpServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			serveErr <- err
 			return

--- a/config.example.yml
+++ b/config.example.yml
@@ -21,6 +21,11 @@ allow_send: false
 # moves messages to Trash and still requires confirm: true on every call.
 allow_delete: false
 
+# Absolute origin used to mint get_attachment download URLs. Required for
+# remote agents: file_path is on this host, so they fetch download_url with
+# curl instead. Leave empty for stdio. Links expire after 15 minutes.
+# public_url: https://mail-mcp.example.com
+
 # ---------------------------------------------------------------------------
 # Limits — bound what a single tool call can cost
 # ---------------------------------------------------------------------------

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -119,6 +119,11 @@ type Config struct {
 	RawTimeouts rawTimeouts `yaml:"timeouts"`
 	Accounts    []*Account  `yaml:"accounts"`
 
+	// PublicURL is the absolute origin clients use to fetch attachments
+	// over HTTP. Empty means get_attachment will not mint a download_url
+	// (stdio deployments, or HTTP without a known public hostname).
+	PublicURL string `yaml:"public_url"`
+
 	// IdleConnTTL is how long a pooled IMAP connection may sit unused
 	// before it is closed.
 	IdleConnTTL time.Duration `yaml:"-"`
@@ -160,6 +165,8 @@ func Load(path string) (*Config, error) {
 }
 
 func (c *Config) normalize() error {
+	c.PublicURL = strings.TrimRight(strings.TrimSpace(c.PublicURL), "/")
+
 	if c.Limits.MaxBodyChars <= 0 {
 		c.Limits.MaxBodyChars = DefaultMaxBodyChars
 	}
@@ -294,6 +301,9 @@ func defaultSMTPSecurity(port int) Security {
 }
 
 func (c *Config) validate() error {
+	if c.PublicURL != "" && !strings.HasPrefix(c.PublicURL, "http://") && !strings.HasPrefix(c.PublicURL, "https://") {
+		return fmt.Errorf("public_url must be an absolute http(s) URL, got %q", c.PublicURL)
+	}
 	if len(c.Accounts) == 0 {
 		return fmt.Errorf("no accounts configured")
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -216,6 +216,7 @@ func TestLoadRejectsInvalidConfigs(t *testing.T) {
 		"bad timeout":       "timeouts: {imap_connect: soon}\naccounts:\n  - id: a\n    imap: {host: h, username: u@e.com, password: p}",
 		"negative timeout":  "timeouts: {imap_connect: -5s}\naccounts:\n  - id: a\n    imap: {host: h, username: u@e.com, password: p}",
 		"from not an email": "accounts:\n  - id: a\n    from_address: notanemail\n    imap: {host: h, username: u@e.com, password: p}",
+		"bad public_url":    "public_url: mail.example\naccounts:\n  - id: a\n    imap: {host: h, username: u@e.com, password: p}",
 	}
 	for name, body := range cases {
 		t.Run(name, func(t *testing.T) {
@@ -223,6 +224,13 @@ func TestLoadRejectsInvalidConfigs(t *testing.T) {
 				t.Errorf("Load accepted an invalid config (%s)", name)
 			}
 		})
+	}
+}
+
+func TestPublicURLNormalized(t *testing.T) {
+	cfg := loadOK(t, "public_url: https://mail.example/\n"+minimal)
+	if cfg.PublicURL != "https://mail.example" {
+		t.Errorf("public_url = %q, want trailing slash stripped", cfg.PublicURL)
 	}
 }
 

--- a/internal/httpx/download.go
+++ b/internal/httpx/download.go
@@ -1,0 +1,146 @@
+package httpx
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	// DownloadPrefix is the HTTP path get_attachment's signed links live under.
+	DownloadPrefix = "/attachments/"
+	// DownloadTTL is how long a minted link remains valid.
+	DownloadTTL = 15 * time.Minute
+)
+
+var (
+	errBadToken = errors.New("invalid download token")
+	errExpired  = errors.New("download token expired")
+	errBadName  = errors.New("invalid filename")
+	errNotFound = errors.New("attachment not found")
+)
+
+// SignDownload mints a token bound to filename and an expiry DownloadTTL
+// after now. The token is path-safe: digits, a dot, and base64url.
+func SignDownload(secret, filename string, now time.Time) (token string, expires time.Time) {
+	expires = now.Add(DownloadTTL).UTC().Truncate(time.Second)
+	exp := strconv.FormatInt(expires.Unix(), 10)
+	return exp + "." + mac64(secret, exp, filename), expires
+}
+
+// VerifyDownload reports whether token is a valid, unexpired signature for
+// filename. Every failure mode is distinct for tests; the HTTP handler
+// collapses them to 404 so scanners learn nothing.
+func VerifyDownload(secret, token, filename string, now time.Time) error {
+	expStr, mac, ok := strings.Cut(token, ".")
+	if !ok || expStr == "" || mac == "" {
+		return errBadToken
+	}
+	expUnix, err := strconv.ParseInt(expStr, 10, 64)
+	if err != nil {
+		return errBadToken
+	}
+	if !hmac.Equal([]byte(mac), []byte(mac64(secret, expStr, filename))) {
+		return errBadToken
+	}
+	if !now.Before(time.Unix(expUnix, 0).Add(time.Second)) {
+		return errExpired
+	}
+	return nil
+}
+
+// DownloadURL builds the absolute URL an agent can fetch with curl.
+func DownloadURL(baseURL, token, filename string) string {
+	base := strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	return base + DownloadPrefix + token + "/" + url.PathEscape(filename)
+}
+
+// AttachmentHandler serves files previously written by get_attachment.
+//
+// Auth is the signed token in the path, not the bearer header: a remote
+// agent has the MCP bearer, but curl on the agent's machine does not
+// automatically attach it. The token is HMAC'd with the same secret and
+// dies in DownloadTTL, so a leaked URL is a 15-minute window on one file,
+// not a mailbox.
+func AttachmentHandler(secret, dir string, logger *slog.Logger) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet && r.Method != http.MethodHead {
+			w.Header().Set("Allow", "GET, HEAD")
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+
+		path, err := resolveDownload(secret, dir, r.URL.Path, time.Now())
+		if err != nil {
+			logger.Debug("rejected attachment download",
+				"remote", clientIP(r), "err", err.Error())
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		filename := filepath.Base(path)
+		w.Header().Set("Content-Disposition", `attachment; filename="`+filename+`"`)
+		http.ServeFile(w, r, path)
+	})
+}
+
+func resolveDownload(secret, dir, requestPath string, now time.Time) (string, error) {
+	rest, ok := strings.CutPrefix(requestPath, DownloadPrefix)
+	if !ok {
+		return "", errNotFound
+	}
+	token, rawName, ok := strings.Cut(rest, "/")
+	if !ok || token == "" || rawName == "" || strings.Contains(rawName, "/") {
+		return "", errNotFound
+	}
+	name, err := url.PathUnescape(rawName)
+	if err != nil {
+		return "", errBadName
+	}
+	// filepath.Base would turn "../secret" into "secret" and serve it if
+	// the token happened to match. Reject anything that is not already a basename.
+	if name != filepath.Base(name) || name == "" || name == "." || name == ".." {
+		return "", errBadName
+	}
+	if err := VerifyDownload(secret, token, name, now); err != nil {
+		return "", err
+	}
+
+	absDir, err := filepath.Abs(dir)
+	if err != nil {
+		return "", errNotFound
+	}
+	target := filepath.Join(absDir, name)
+	if !underDir(absDir, target) {
+		return "", errBadName
+	}
+	info, err := os.Stat(target)
+	if err != nil || info.IsDir() {
+		return "", errNotFound
+	}
+	return target, nil
+}
+
+func mac64(secret, exp, filename string) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	_, _ = fmt.Fprintf(mac, "%s\n%s", exp, filename)
+	return base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+}
+
+func underDir(dir, path string) bool {
+	rel, err := filepath.Rel(dir, path)
+	if err != nil {
+		return false
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator))
+}

--- a/internal/httpx/download_test.go
+++ b/internal/httpx/download_test.go
@@ -1,0 +1,194 @@
+package httpx
+
+import (
+	"crypto/hmac"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+const testSecret = "s3cret-token-value-long-enough"
+
+func TestSignVerifyRoundTrip(t *testing.T) {
+	now := time.Date(2026, 8, 23, 12, 0, 0, 0, time.UTC)
+	token, exp := SignDownload(testSecret, "445-4-photo.jpg", now)
+	if !exp.Equal(now.Add(DownloadTTL)) {
+		t.Fatalf("expires = %s, want %s", exp, now.Add(DownloadTTL))
+	}
+	if err := VerifyDownload(testSecret, token, "445-4-photo.jpg", now); err != nil {
+		t.Fatalf("fresh token rejected: %v", err)
+	}
+	if err := VerifyDownload(testSecret, token, "445-4-photo.jpg", exp.Add(-time.Second)); err != nil {
+		t.Fatalf("token rejected a second before expiry: %v", err)
+	}
+}
+
+func TestVerifyRejectsTampering(t *testing.T) {
+	now := time.Now()
+	token, _ := SignDownload(testSecret, "invoice.pdf", now)
+
+	if err := VerifyDownload(testSecret, token, "other.pdf", now); err != errBadToken {
+		t.Errorf("wrong filename: %v", err)
+	}
+	if err := VerifyDownload("different-secret-value", token, "invoice.pdf", now); err != errBadToken {
+		t.Errorf("wrong secret: %v", err)
+	}
+	if err := VerifyDownload(testSecret, token+"x", "invoice.pdf", now); err != errBadToken {
+		t.Errorf("appended junk: %v", err)
+	}
+	if err := VerifyDownload(testSecret, "not-a-token", "invoice.pdf", now); err != errBadToken {
+		t.Errorf("garbage: %v", err)
+	}
+	if err := VerifyDownload(testSecret, "", "invoice.pdf", now); err != errBadToken {
+		t.Errorf("empty: %v", err)
+	}
+
+	expStr, mac, _ := strings.Cut(token, ".")
+	if err := VerifyDownload(testSecret, expStr+".", "invoice.pdf", now); err != errBadToken {
+		t.Errorf("empty mac: %v", err)
+	}
+	if err := VerifyDownload(testSecret, "."+mac, "invoice.pdf", now); err != errBadToken {
+		t.Errorf("empty expiry: %v", err)
+	}
+}
+
+func TestVerifyRejectsExpired(t *testing.T) {
+	now := time.Now()
+	token, exp := SignDownload(testSecret, "invoice.pdf", now)
+	if err := VerifyDownload(testSecret, token, "invoice.pdf", exp.Add(time.Second)); err != errExpired {
+		t.Errorf("expired token: %v, want errExpired", err)
+	}
+}
+
+func TestVerifyUsesConstantTimeCompare(t *testing.T) {
+	// Guard the comparison itself: a future edit that swaps hmac.Equal for
+	// == would still pass the tamper tests but lose the constant-time
+	// property. hmac.Equal on equal inputs must return true here.
+	if !hmac.Equal([]byte("abc"), []byte("abc")) {
+		t.Fatal("hmac.Equal is broken; download tokens cannot be verified")
+	}
+}
+
+func TestDownloadURLEscapesFilename(t *testing.T) {
+	got := DownloadURL("https://mail.example/", "123.abc", "Schloss Biesendahl.jpg")
+	want := "https://mail.example/attachments/123.abc/Schloss%20Biesendahl.jpg"
+	if got != want {
+		t.Errorf("url = %q, want %q", got, want)
+	}
+}
+
+func TestAttachmentHandlerServesFile(t *testing.T) {
+	dir := t.TempDir()
+	name := "445-4-Schloss Biesendahl.jpg"
+	body := []byte("jpeg-bytes")
+	if err := os.WriteFile(filepath.Join(dir, name), body, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Now()
+	token, _ := SignDownload(testSecret, name, now)
+	handler := AttachmentHandler(testSecret, dir, discardLogger())
+
+	req := httptest.NewRequest(http.MethodGet, DownloadURL("http://mail.example", token, name), nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if got := rec.Body.Bytes(); string(got) != string(body) {
+		t.Errorf("body = %q, want %q", got, body)
+	}
+	if disp := rec.Header().Get("Content-Disposition"); !strings.Contains(disp, name) {
+		t.Errorf("Content-Disposition = %q, want it to name the file", disp)
+	}
+}
+
+func TestAttachmentHandlerHEAD(t *testing.T) {
+	dir := t.TempDir()
+	name := "file.bin"
+	if err := os.WriteFile(filepath.Join(dir, name), []byte("abcd"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	token, _ := SignDownload(testSecret, name, time.Now())
+	handler := AttachmentHandler(testSecret, dir, discardLogger())
+
+	req := httptest.NewRequest(http.MethodHead, DownloadPrefix+token+"/"+name, nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if rec.Body.Len() != 0 {
+		t.Errorf("HEAD should have an empty body, got %q", rec.Body.String())
+	}
+}
+
+func TestAttachmentHandlerRejectsBadRequests(t *testing.T) {
+	dir := t.TempDir()
+	name := "ok.bin"
+	if err := os.WriteFile(filepath.Join(dir, name), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	token, _ := SignDownload(testSecret, name, time.Now())
+	handler := AttachmentHandler(testSecret, dir, discardLogger())
+
+	cases := map[string]string{
+		"missing token":  DownloadPrefix + name,
+		"no filename":    DownloadPrefix + token + "/",
+		"wrong filename": DownloadPrefix + token + "/other.bin",
+		"garbage token":  DownloadPrefix + "nope/ok.bin",
+		"missing file":   DownloadPrefix + func() string { tkn, _ := SignDownload(testSecret, "gone.bin", time.Now()); return tkn }() + "/gone.bin",
+		"path traversal": DownloadPrefix + token + "/..%2Fok.bin",
+		"nested path":    DownloadPrefix + token + "/a/ok.bin",
+		"outside prefix": "/mcp",
+	}
+	for name, path := range cases {
+		t.Run(name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
+			if rec.Code != http.StatusNotFound {
+				t.Errorf("status = %d, want 404", rec.Code)
+			}
+			if rec.Body.Len() != 0 {
+				t.Errorf("404 body should be empty, got %q", rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestAttachmentHandlerRejectsPOST(t *testing.T) {
+	handler := AttachmentHandler(testSecret, t.TempDir(), discardLogger())
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, DownloadPrefix+"x/y", nil))
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Errorf("status = %d, want 405", rec.Code)
+	}
+	if rec.Header().Get("Allow") == "" {
+		t.Error("405 should advertise Allow")
+	}
+}
+
+func TestResolveDownloadRejectsDotDotName(t *testing.T) {
+	_, err := resolveDownload(testSecret, t.TempDir(), DownloadPrefix+"tok/..", time.Now())
+	if err == nil {
+		t.Fatal("accepted .. as a filename")
+	}
+}
+
+func TestUnderDir(t *testing.T) {
+	if !underDir("/var/lib/mail", "/var/lib/mail/a.jpg") {
+		t.Error("child should be under parent")
+	}
+	if underDir("/var/lib/mail", "/var/lib/mail/../etc/passwd") {
+		t.Error("escaped path accepted")
+	}
+	if underDir("/var/lib/mail", "/etc/passwd") {
+		t.Error("other tree accepted")
+	}
+}

--- a/internal/httpx/handler.go
+++ b/internal/httpx/handler.go
@@ -1,0 +1,31 @@
+package httpx
+
+import (
+	"log/slog"
+	"net/http"
+)
+
+const mcpPath = "/mcp"
+
+// Handler is the HTTP surface: bearer-authenticated /mcp, and
+// signed-URL /attachments/ for files get_attachment has already written.
+func Handler(apiKey string, logger *slog.Logger, trustProxy bool, getRPM, postRPM int, mcp, attachments http.Handler) http.Handler {
+	limiter := NewRateLimiter(getRPM, postRPM, trustProxy)
+
+	wrap := func(inner http.Handler, bearer bool) http.Handler {
+		if bearer {
+			inner = RequireBearer(apiKey, logger, inner)
+		}
+		inner = limiter.Middleware(inner)
+		inner = SecurityHeaders(inner)
+		inner = LogRequests(logger, inner)
+		return inner
+	}
+
+	mux := http.NewServeMux()
+	mcpWrapped := wrap(mcp, true)
+	mux.Handle(mcpPath, mcpWrapped)
+	mux.Handle(mcpPath+"/", mcpWrapped)
+	mux.Handle(DownloadPrefix, wrap(attachments, false))
+	return OnlyPath(mux, mcpPath, DownloadPrefix)
+}

--- a/internal/httpx/handler_test.go
+++ b/internal/httpx/handler_test.go
@@ -1,0 +1,69 @@
+package httpx
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestHandlerSplitsAuth(t *testing.T) {
+	dir := t.TempDir()
+	name := "photo.jpg"
+	if err := os.WriteFile(filepath.Join(dir, name), []byte("jpeg"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	token, _ := SignDownload(testSecret, name, time.Now())
+
+	mcpHit := false
+	mcp := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		mcpHit = true
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := Handler(testSecret, discardLogger(), false, 0, 0, mcp, AttachmentHandler(testSecret, dir, discardLogger()))
+
+	t.Run("mcp without bearer is 401", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/mcp", nil))
+		if rec.Code != http.StatusUnauthorized {
+			t.Errorf("status = %d, want 401", rec.Code)
+		}
+		if mcpHit {
+			t.Error("mcp handler ran without a bearer token")
+		}
+	})
+
+	t.Run("mcp with bearer reaches the inner handler", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+		req.Header.Set("Authorization", "Bearer "+testSecret)
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Errorf("status = %d, want 200", rec.Code)
+		}
+		if !mcpHit {
+			t.Error("mcp handler was not reached")
+		}
+	})
+
+	t.Run("attachment without bearer is 200", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, DownloadPrefix+token+"/"+name, nil))
+		if rec.Code != http.StatusOK {
+			t.Errorf("status = %d, want 200", rec.Code)
+		}
+		if rec.Body.String() != "jpeg" {
+			t.Errorf("body = %q", rec.Body.String())
+		}
+	})
+
+	t.Run("unknown path is empty 404", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/admin", nil))
+		if rec.Code != http.StatusNotFound || rec.Body.Len() != 0 {
+			t.Errorf("status = %d body %q", rec.Code, rec.Body.String())
+		}
+	})
+}

--- a/internal/httpx/middleware.go
+++ b/internal/httpx/middleware.go
@@ -48,17 +48,19 @@ func bearerToken(r *http.Request) (string, bool) {
 	return strings.TrimSpace(header[len(prefix):]), true
 }
 
-// OnlyPath returns 404 for every request outside the given prefix.
+// OnlyPath returns 404 for every request outside the given prefixes.
 //
 // An empty body reveals nothing about what is running here, which keeps the
 // endpoint uninteresting to opportunistic scanners.
-func OnlyPath(prefix string, next http.Handler) http.Handler {
+func OnlyPath(next http.Handler, prefixes ...string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if !strings.HasPrefix(r.URL.Path, prefix) {
-			w.WriteHeader(http.StatusNotFound)
-			return
+		for _, prefix := range prefixes {
+			if strings.HasPrefix(r.URL.Path, prefix) {
+				next.ServeHTTP(w, r)
+				return
+			}
 		}
-		next.ServeHTTP(w, r)
+		w.WriteHeader(http.StatusNotFound)
 	})
 }
 

--- a/internal/httpx/middleware_test.go
+++ b/internal/httpx/middleware_test.go
@@ -65,16 +65,19 @@ func TestRequireBearerAdvertisesTheScheme(t *testing.T) {
 }
 
 func TestOnlyPath(t *testing.T) {
-	handler := OnlyPath("/mcp", okHandler())
+	handler := OnlyPath(okHandler(), "/mcp", DownloadPrefix)
 
 	cases := map[string]int{
-		"/mcp":         http.StatusOK,
-		"/mcp/":        http.StatusOK,
-		"/mcp/session": http.StatusOK,
-		"/":            http.StatusNotFound,
-		"/health":      http.StatusNotFound,
-		"/.env":        http.StatusNotFound,
-		"/admin":       http.StatusNotFound,
+		"/mcp":           http.StatusOK,
+		"/mcp/":          http.StatusOK,
+		"/mcp/session":   http.StatusOK,
+		"/attachments/":  http.StatusOK,
+		"/attachments/x": http.StatusOK,
+		"/":              http.StatusNotFound,
+		"/health":        http.StatusNotFound,
+		"/.env":          http.StatusNotFound,
+		"/admin":         http.StatusNotFound,
+		"/attachment":    http.StatusNotFound,
 	}
 	for path, want := range cases {
 		rec := httptest.NewRecorder()
@@ -87,7 +90,7 @@ func TestOnlyPath(t *testing.T) {
 
 func TestOnlyPathRevealsNothing(t *testing.T) {
 	rec := httptest.NewRecorder()
-	OnlyPath("/mcp", okHandler()).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/admin", nil))
+	OnlyPath(okHandler(), "/mcp").ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/admin", nil))
 	if rec.Body.Len() != 0 {
 		t.Errorf("404 body should be empty, got %q", rec.Body.String())
 	}

--- a/internal/tools/accounts.go
+++ b/internal/tools/accounts.go
@@ -44,6 +44,7 @@ type serverInfoOutput struct {
 	MaxSearchResults   int      `json:"max_search_results" jsonschema:"largest page size search_emails will return"`
 	MaxAttachmentBytes int64    `json:"max_attachment_bytes" jsonschema:"largest attachment get_attachment will download"`
 	AttachmentDir      string   `json:"attachment_dir" jsonschema:"default directory get_attachment writes into"`
+	PublicURL          string   `json:"public_url,omitempty" jsonschema:"origin used to mint download_url on get_attachment; empty when downloads are unavailable"`
 }
 
 func (s *Server) registerAccounts(srv *mcp.Server) {
@@ -132,5 +133,6 @@ func (s *Server) serverInfo(_ context.Context, _ *mcp.CallToolRequest, _ struct{
 		MaxSearchResults:   s.cfg.Limits.MaxSearchResults,
 		MaxAttachmentBytes: s.cfg.Limits.MaxAttachmentBytes,
 		AttachmentDir:      s.cfg.Limits.AttachmentDir,
+		PublicURL:          s.cfg.PublicURL,
 	}, nil
 }

--- a/internal/tools/helpers_test.go
+++ b/internal/tools/helpers_test.go
@@ -1,7 +1,10 @@
 package tools
 
 import (
+	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
 	imap "github.com/emersion/go-imap/v2"
 
@@ -348,6 +351,37 @@ func TestFirstNonEmpty(t *testing.T) {
 	}
 	if got := firstNonEmpty("", "   "); got != "" {
 		t.Errorf("got %q, want empty", got)
+	}
+}
+
+func TestMintDownloadRequiresPublicURLAndSecret(t *testing.T) {
+	dir := t.TempDir()
+	abs := filepath.Join(dir, "a.jpg")
+	s := &Server{
+		cfg:            &config.Config{Limits: config.Limits{AttachmentDir: dir}},
+		downloadSecret: "secret-token-value-long-enough",
+	}
+	if _, _, ok := s.mintDownload("a.jpg", abs); ok {
+		t.Fatal("minted a URL without public_url")
+	}
+	s.cfg.PublicURL = "https://mail.example"
+	s.downloadSecret = ""
+	if _, _, ok := s.mintDownload("a.jpg", abs); ok {
+		t.Fatal("minted a URL without a signing secret")
+	}
+	s.downloadSecret = "secret-token-value-long-enough"
+	url, exp, ok := s.mintDownload("a.jpg", abs)
+	if !ok {
+		t.Fatal("should mint when public_url, secret, and the configured dir all match")
+	}
+	if !strings.HasPrefix(url, "https://mail.example/attachments/") || !strings.HasSuffix(url, "/a.jpg") {
+		t.Errorf("url = %q", url)
+	}
+	if exp.Before(time.Now()) {
+		t.Error("expiry is in the past")
+	}
+	if _, _, ok := s.mintDownload("a.jpg", filepath.Join(t.TempDir(), "a.jpg")); ok {
+		t.Fatal("minted a URL for a file outside the configured attachment dir")
 	}
 }
 

--- a/internal/tools/read.go
+++ b/internal/tools/read.go
@@ -11,6 +11,7 @@ import (
 	imap "github.com/emersion/go-imap/v2"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
+	"github.com/kacperkwapisz/mail-mcp/internal/httpx"
 	"github.com/kacperkwapisz/mail-mcp/internal/mailbox"
 	"github.com/kacperkwapisz/mail-mcp/internal/mailmime"
 )
@@ -68,12 +69,14 @@ type getAttachmentInput struct {
 }
 
 type getAttachmentOutput struct {
-	Summary     string `json:"summary" jsonschema:"one-line description of the result"`
-	FilePath    string `json:"file_path" jsonschema:"absolute path of the written file; pass this to a local file-reading tool"`
-	Filename    string `json:"filename" jsonschema:"sanitized filename on disk"`
-	ContentType string `json:"content_type" jsonschema:"MIME type of the attachment"`
-	SizeBytes   int    `json:"size_bytes" jsonschema:"size of the written file"`
-	PartID      string `json:"part_id" jsonschema:"part id that was matched"`
+	Summary         string `json:"summary" jsonschema:"one-line description of the result"`
+	FilePath        string `json:"file_path" jsonschema:"absolute path of the written file on the server; not usable from a remote agent"`
+	DownloadURL     string `json:"download_url,omitempty" jsonschema:"HTTP URL that serves this file for 15 minutes; curl it onto the agent's machine. Empty on stdio or when public_url is unset"`
+	DownloadExpires string `json:"download_expires_at,omitempty" jsonschema:"RFC 3339 expiry of download_url"`
+	Filename        string `json:"filename" jsonschema:"sanitized filename on disk"`
+	ContentType     string `json:"content_type" jsonschema:"MIME type of the attachment"`
+	SizeBytes       int    `json:"size_bytes" jsonschema:"size of the written file"`
+	PartID          string `json:"part_id" jsonschema:"part id that was matched"`
 }
 
 func (s *Server) registerRead(srv *mcp.Server) {
@@ -97,9 +100,9 @@ func (s *Server) registerRead(srv *mcp.Server) {
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:  "get_attachment",
 		Title: "Download an attachment",
-		Description: "Write one attachment to a file on disk and return its path. The bytes are deliberately kept out of the response " +
-			"so a large file cannot flood the context; open the returned path with a local file tool instead. " +
-			"Select the attachment by part_id (preferred) or filename, both from read_email.",
+		Description: "Write one attachment to a file on the server. Bytes stay out of the response so a large file cannot flood the " +
+			"context. Returns file_path (server-local) and, on HTTP with public_url set, a download_url the agent can curl onto " +
+			"its own machine. The link expires in 15 minutes. Select by part_id (preferred) or filename, both from read_email.",
 		Annotations: writeTool(),
 	}, s.getAttachment)
 }
@@ -269,14 +272,34 @@ func (s *Server) getAttachment(ctx context.Context, _ *mcp.CallToolRequest, in g
 		abs = path
 	}
 
-	return nil, getAttachmentOutput{
+	out := getAttachmentOutput{
 		Summary:     fmt.Sprintf("saved %s (%d bytes) to %s", safeName, len(extracted.Content), abs),
 		FilePath:    abs,
-		Filename:    safeName,
+		Filename:    diskName,
 		ContentType: extracted.ContentType,
 		SizeBytes:   len(extracted.Content),
 		PartID:      extracted.PartID,
-	}, nil
+	}
+	if url, exp, ok := s.mintDownload(diskName, abs); ok {
+		out.DownloadURL = url
+		out.DownloadExpires = exp.Format(time.RFC3339)
+		out.Summary += "; fetch download_url onto this machine before it expires"
+	}
+	return nil, out, nil
+}
+
+func (s *Server) mintDownload(diskName, absPath string) (string, time.Time, bool) {
+	if s.cfg.PublicURL == "" || s.downloadSecret == "" {
+		return "", time.Time{}, false
+	}
+	// The HTTP handler only serves the configured attachment dir. A custom
+	// output_dir is for local use; minting a URL that 404s would be a lie.
+	configured, err := filepath.Abs(s.cfg.Limits.AttachmentDir)
+	if err != nil || filepath.Dir(absPath) != configured {
+		return "", time.Time{}, false
+	}
+	token, exp := httpx.SignDownload(s.downloadSecret, diskName, time.Now())
+	return httpx.DownloadURL(s.cfg.PublicURL, token, diskName), exp, true
 }
 
 // ---- helpers ---------------------------------------------------------------

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -21,15 +21,17 @@ import (
 
 // Server holds the dependencies shared by every tool handler.
 type Server struct {
-	cfg     *config.Config
-	pool    *mailbox.Pool
-	logger  *slog.Logger
-	version string
+	cfg            *config.Config
+	pool           *mailbox.Pool
+	logger         *slog.Logger
+	version        string
+	downloadSecret string
 }
 
-// New builds a tool server.
-func New(cfg *config.Config, pool *mailbox.Pool, logger *slog.Logger, version string) *Server {
-	return &Server{cfg: cfg, pool: pool, logger: logger, version: version}
+// New builds a tool server. downloadSecret is the HMAC key for attachment
+// download URLs; empty disables minting them (stdio, or HTTP without a token).
+func New(cfg *config.Config, pool *mailbox.Pool, logger *slog.Logger, version, downloadSecret string) *Server {
+	return &Server{cfg: cfg, pool: pool, logger: logger, version: version, downloadSecret: downloadSecret}
 }
 
 // Register attaches every tool to the MCP server.
@@ -71,7 +73,10 @@ instead. Send only what the user approved.
 READING COSTS CONTEXT. search_emails returns metadata only. read_email returns
 one message and omits HTML unless you ask for it. Attachment bytes are never
 inlined — read_email lists attachment metadata, and get_attachment writes a
-chosen file to disk and returns its path.
+chosen file to the server and returns file_path plus, on HTTP, a download_url.
+file_path is on the server, not the agent's machine. Fetch download_url with
+curl (or any HTTP client) to a local path, then open that local file. The
+link expires in 15 minutes; call get_attachment again for a fresh one.
 
 DESTRUCTIVE ACTIONS. Prefer archive_email over delete_email. Deleting requires
 confirm: true, and moves the message to Trash rather than erasing it.`

--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -62,7 +62,7 @@ func connect(t *testing.T, cfg *config.Config) *mcp.ClientSession {
 
 	srv := mcp.NewServer(&mcp.Implementation{Name: "mail-mcp", Version: "test"},
 		&mcp.ServerOptions{Instructions: Instructions})
-	New(cfg, pool, logger, "test").Register(srv)
+	New(cfg, pool, logger, "test", "").Register(srv)
 
 	clientTransport, serverTransport := mcp.NewInMemoryTransports()
 	ctx := context.Background()
@@ -492,7 +492,7 @@ func TestInstructionsCoverTheCriticalRules(t *testing.T) {
 		"never concatenate",
 		"approval",
 		"confirm: true",
-		"get_attachment",
+		"get_attachment", "download_url",
 	} {
 		if !strings.Contains(strings.ToLower(Instructions), strings.ToLower(needle)) {
 			t.Errorf("instructions no longer mention %q", needle)


### PR DESCRIPTION
Remote agents cannot open `file_path` — it lives on the server. A 7 MB JPEG base64'd into the tool result would blow the context window, so bytes still never enter the MCP response.

When `public_url` is set, `get_attachment` now also returns a signed `download_url` the agent can curl onto its own machine.

- Token is HMAC-SHA256 of expiry + filename, keyed with `MCP_API_KEY`
- `GET /attachments/<token>/<filename>` does not take a bearer, so curl works
- `/mcp` still requires the bearer
- Bad or expired tokens 404 with an empty body
- Links die after 15 minutes; call `get_attachment` again for a fresh one
- A custom `output_dir` is not served (the handler only reads the configured attachment dir)

Set `public_url: https://mail-mcp.example.com` in config.yml and redeploy.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds signed download URLs to `get_attachment` so remote agents can fetch attachments. Previously it returned only a server-local `file_path`; now, when `public_url` is set, it also returns a 15‑minute `download_url` served from `/attachments/...` without a bearer.

- Security and HTTP surface: `internal/httpx` adds token mint/verify (HMAC‑SHA256 of expiry+filename keyed by `MCP_API_KEY`), an unauthenticated `AttachmentHandler` under `/attachments/`, and a unified `Handler` that keeps `/mcp` bearer‑protected. Invalid or expired tokens 404 with an empty body. Only files under the configured `limits.attachment_dir` are served; traversal and nested paths are rejected. `OnlyPath` now accepts multiple prefixes.
- Tool and config changes: `get_attachment` returns `download_url` and `download_expires_at` when available; it still writes the file and returns `file_path`. `tools.New` now takes a download signing secret (the same `MCP_API_KEY`). Config adds `public_url` (normalized, validated) and server info exposes it. Docs updated.
- Rollout: set `public_url: https://<origin>` in config and ensure `MCP_API_KEY` is set; redeploy. Remote agents should curl `download_url` to a local path; stdio or empty `public_url` keeps the old behavior (no URL). Custom `output_dir` paths are not downloadable. Links expire after 15 minutes; call `get_attachment` again for a fresh URL.

<sup>Written for commit 98cefcfc24754633af20aa8fd1ff959f4d82a18d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kacperkwapisz/mail-mcp/pull/22?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

