### PR TITLE
Compare download errors with errors.Is

### DIFF
--- a/internal/httpx/download_test.go
+++ b/internal/httpx/download_test.go
@@ -2,6 +2,7 @@ package httpx
 
 import (
 	"crypto/hmac"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -31,27 +32,27 @@ func TestVerifyRejectsTampering(t *testing.T) {
 	now := time.Now()
 	token, _ := SignDownload(testSecret, "invoice.pdf", now)
 
-	if err := VerifyDownload(testSecret, token, "other.pdf", now); err != errBadToken {
+	if err := VerifyDownload(testSecret, token, "other.pdf", now); !errors.Is(err, errBadToken) {
 		t.Errorf("wrong filename: %v", err)
 	}
-	if err := VerifyDownload("different-secret-value", token, "invoice.pdf", now); err != errBadToken {
+	if err := VerifyDownload("different-secret-value", token, "invoice.pdf", now); !errors.Is(err, errBadToken) {
 		t.Errorf("wrong secret: %v", err)
 	}
-	if err := VerifyDownload(testSecret, token+"x", "invoice.pdf", now); err != errBadToken {
+	if err := VerifyDownload(testSecret, token+"x", "invoice.pdf", now); !errors.Is(err, errBadToken) {
 		t.Errorf("appended junk: %v", err)
 	}
-	if err := VerifyDownload(testSecret, "not-a-token", "invoice.pdf", now); err != errBadToken {
+	if err := VerifyDownload(testSecret, "not-a-token", "invoice.pdf", now); !errors.Is(err, errBadToken) {
 		t.Errorf("garbage: %v", err)
 	}
-	if err := VerifyDownload(testSecret, "", "invoice.pdf", now); err != errBadToken {
+	if err := VerifyDownload(testSecret, "", "invoice.pdf", now); !errors.Is(err, errBadToken) {
 		t.Errorf("empty: %v", err)
 	}
 
 	expStr, mac, _ := strings.Cut(token, ".")
-	if err := VerifyDownload(testSecret, expStr+".", "invoice.pdf", now); err != errBadToken {
+	if err := VerifyDownload(testSecret, expStr+".", "invoice.pdf", now); !errors.Is(err, errBadToken) {
 		t.Errorf("empty mac: %v", err)
 	}
-	if err := VerifyDownload(testSecret, "."+mac, "invoice.pdf", now); err != errBadToken {
+	if err := VerifyDownload(testSecret, "."+mac, "invoice.pdf", now); !errors.Is(err, errBadToken) {
 		t.Errorf("empty expiry: %v", err)
 	}
 }
@@ -59,7 +60,7 @@ func TestVerifyRejectsTampering(t *testing.T) {
 func TestVerifyRejectsExpired(t *testing.T) {
 	now := time.Now()
 	token, exp := SignDownload(testSecret, "invoice.pdf", now)
-	if err := VerifyDownload(testSecret, token, "invoice.pdf", exp.Add(time.Second)); err != errExpired {
+	if err := VerifyDownload(testSecret, token, "invoice.pdf", exp.Add(time.Second)); !errors.Is(err, errExpired) {
 		t.Errorf("expired token: %v, want errExpired", err)
 	}
 }


### PR DESCRIPTION
golangci-lint `errorlint` rejected `err != errBadToken` in the download token tests. Same checks, via `errors.Is`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use `errors.Is` in download verification tests instead of direct comparisons to errBadToken and errExpired. This resolves `golangci-lint` `errorlint` warnings and keeps the tests resilient to wrapped errors; runtime behavior does not change.

<sup>Written for commit d1f9dab1aa21e3ecacb4999efa130613cfb715a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kacperkwapisz/mail-mcp/pull/23?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

